### PR TITLE
Is bioconda also a user?

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -28,6 +28,7 @@
     tess: Bioconda
   related_pages:
     - resources
+    - user
 - id: biocontainers
   name: BioContainers
   url: https://biocontainers.pro


### PR DESCRIPTION
Bioconda can also link to bio.tools, containers or Galaxy instances ... does this classify as a `user`?