### PR TITLE
feat: links in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,5 +50,7 @@ plugins:
 theme_variables: 
  topnav:
    brand_logo: assets/img/logo-rsec.svg
+   search: false
+   github: false
  headings:
    resource-table-all: " " 

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,8 +1,24 @@
-copyright: 
+copyright: "&copy; 2024 Research Software Ecosystem"
 extra_line: 
 columns:
   - type: links
-    width: 3
-    children: 
+    width: 2
+    children:
+      - url_text: Credits
+        url: /contributors
       - url_text: License
         url: /licence
+  - type: links
+    width: 2
+    children:
+      - url_text: Contacts
+        url: /contacts
+      - url_text: Report an issue
+        url: https://github.com/research-software-ecosystem/content/issues
+  - type: links
+    width: 2
+    children:
+      - url_text: Website source
+        url: https://github.com/research-software-ecosystem/research-software-ecosystem.github.io
+      - url_text: Metadata repository
+        url: https://github.com/research-software-ecosystem/content

--- a/_sass/custom_classes.scss
+++ b/_sass/custom_classes.scss
@@ -1,0 +1,6 @@
+/* Theme v5 still renders the topnav search UI even with search: false. */
+header .nav-break,
+header form[role="search"],
+header #search-results {
+  display: none !important;
+}


### PR DESCRIPTION
This PR aims to resolve #29 by adding some links in the footer and a copyright notice. The year is hard-coded, but I didn't like the automated solutions as they required too much code. I'd rather suggest this from the theme template instead.

<img width="1351" height="153" alt="image" src="https://github.com/user-attachments/assets/86f409db-07a0-4b4e-8583-46b36e837f6f" />
